### PR TITLE
Add the codecentric helm charts repository.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -266,6 +266,12 @@
                     <version>6.13.0</version>
                     <extensions>true</extensions>
                     <configuration>
+                        <helmExtraRepos>
+                            <helmRepo>
+                                <name>Codecentric Helm Charts</name>
+                                <url>https://codecentric.github.io/helm-charts</url>
+                            </helmRepo>
+                        </helmExtraRepos>
                         <chartVersion>${project.version}</chartVersion>
                         <chartDirectory>${project.basedir}/helm/target/chart</chartDirectory>
                         <useLocalHelmBinary>false</useLocalHelmBinary>


### PR DESCRIPTION
Lacking the helmRepo entry for codecentric, I get the following errors for the package and install lifecycles.
```
[INFO] Build chart dependencies for .../keycloak-custom-tutorial/helm/src/generated/keycloak-custom-chart ...
[ERROR] Error: no repository definition for https://codecentric.github.io/helm-charts. Please add the missing repos via 'helm repo add'
[ERROR] helm.go:92: 2025-11-05 10:41:30.207529 +0100 CET m=+0.022427418 [debug] no repository definition for https://codecentric.github.io/helm-charts. Please add the missing repos via 'helm repo add'
```