### PR TITLE
Updates the Keycloak version to 26.5.3. Updates the keycloak-config-c…

### DIFF
--- a/container/pom.xml
+++ b/container/pom.xml
@@ -36,7 +36,7 @@
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>junit-jupiter</artifactId>
+            <artifactId>testcontainers-junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -46,7 +46,7 @@
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>postgresql</artifactId>
+            <artifactId>testcontainers-postgresql</artifactId>
             <scope>test</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/commons-logging/commons-logging -->

--- a/pom.xml
+++ b/pom.xml
@@ -33,15 +33,14 @@
         <docker.imagePropertyConfiguration>override</docker.imagePropertyConfiguration>
         <helm.registry>ghcr.io/inventage/keycloak-custom</helm.registry>
         <!-- versions -->
-        <keycloak.version>26.5.2</keycloak.version> <!-- update also keycloak-config-cli.version -->
-        <keycloak-config-cli.version>26.1.0_v6.4.0</keycloak-config-cli.version> <!-- from https://github.com/adorsys/keycloak-config-cli/releases -->
-        <auto-service.version>1.0.1</auto-service.version>
+        <keycloak.version>26.5.3</keycloak.version> <!-- update also keycloak-config-cli.version -->
+        <keycloak-config-cli.version>26.1.0_v6.4.1</keycloak-config-cli.version> <!-- from https://github.com/adorsys/keycloak-config-cli/releases -->
+        <auto-service.version>1.1.1</auto-service.version>
         <!-- https://github.com/dasniko/testcontainers-keycloak/releases -->
-        <testcontainers-keycloak.version>3.7.0</testcontainers-keycloak.version>
-        <testcontainers-postgres.version>1.21.1</testcontainers-postgres.version>
-        <testcontainers.version>1.20.6</testcontainers.version>
-        <junit-jupiter-engine.version>5.12.1</junit-jupiter-engine.version>
-        <failsafe-plugin.version>3.2.5</failsafe-plugin.version>
+        <testcontainers-keycloak.version>4.1.1</testcontainers-keycloak.version>
+        <testcontainers-postgres.version>2.0.1</testcontainers-postgres.version>
+        <testcontainers.version>2.0.3</testcontainers.version>
+        <failsafe-plugin.version>3.5.4</failsafe-plugin.version>
         <chart.directory>${project.basedir}/src/generated/keycloak-custom-chart</chart.directory>
     </properties>
 
@@ -77,13 +76,13 @@
             </dependency>
             <dependency>
                 <groupId>org.testcontainers</groupId>
-                <artifactId>junit-jupiter</artifactId>
+                <artifactId>testcontainers-junit-jupiter</artifactId>
                 <version>${testcontainers.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.testcontainers</groupId>
-                <artifactId>postgresql</artifactId>
+                <artifactId>testcontainers-postgresql</artifactId>
                 <version>${testcontainers-postgres.version}</version>
                 <scope>test</scope>
             </dependency>
@@ -102,17 +101,17 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-enforcer-plugin</artifactId>
-                    <version>3.0.0-M3</version>
+                    <version>3.6.2</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-install-plugin</artifactId>
-                    <version>2.4</version>
+                    <version>3.1.4</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-deploy-plugin</artifactId>
-                    <version>3.1.1</version>
+                    <version>3.1.4</version>
                     <configuration>
                         <skip>true</skip>
                     </configuration>
@@ -120,27 +119,27 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-site-plugin</artifactId>
-                    <version>3.12.1</version>
+                    <version>3.21.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-antrun-plugin</artifactId>
-                    <version>1.8</version>
+                    <version>3.2.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-clean-plugin</artifactId>
-                    <version>3.1.0</version>
+                    <version>3.5.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>2.4</version>
+                    <version>3.5.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.8.1</version>
+                    <version>3.15.0</version>
                     <configuration>
                         <source>${maven.compiler.release}</source>
                         <target>${maven.compiler.release}</target>
@@ -150,7 +149,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.5.0</version>
+                    <version>3.5.4</version>
                     <configuration>
                         <excludedGroups>integration</excludedGroups>
                         <systemPropertyVariables>
@@ -167,7 +166,6 @@
                     <version>${failsafe-plugin.version}</version>
                     <configuration>
                         <systemPropertyVariables>
-                            <api.version>1.44</api.version> <!-- https://github.com/testcontainers/testcontainers-java/issues/11212 -->
                             <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                         </systemPropertyVariables>
                         <includes>
@@ -187,28 +185,28 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-resources-plugin</artifactId>
-                    <version>3.1.0</version>
+                    <version>3.3.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <version>3.8.1</version>
+                    <version>3.10.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-assembly-plugin</artifactId>
-                    <version>3.3.0</version>
+                    <version>3.8.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>exec-maven-plugin</artifactId>
-                    <version>1.6.0</version>
+                    <version>3.6.3</version>
                 </plugin>
                 <!-- for building Docker images: https://github.com/fabric8io/docker-maven-plugin -->
                 <plugin>
                     <groupId>io.fabric8</groupId>
                     <artifactId>docker-maven-plugin</artifactId>
-                    <version>0.45.0</version>
+                    <version>0.48.1</version>
                     <configuration>
                         <images>
                             <image>
@@ -260,7 +258,7 @@
                     <!-- See https://github.com/kokuwaio/helm-maven-plugin for documentation -->
                     <groupId>io.kokuwa.maven</groupId>
                     <artifactId>helm-maven-plugin</artifactId>
-                    <version>6.13.0</version>
+                    <version>6.17.0</version>
                     <extensions>true</extensions>
                     <configuration>
                         <helmExtraRepos>
@@ -343,7 +341,7 @@
                                     </unCheckedPluginList>
                                 </requirePluginVersions>
                                 <requireMavenVersion>
-                                    <version>3.6.0</version>
+                                    <version>3.6.3</version>
                                 </requireMavenVersion>
                                 <requireJavaVersion>
                                     <version>${maven.compiler.release}</version>


### PR DESCRIPTION
…li to v6.4.1. Update various dependencies and plugins. Remove the api version workaround regarding testcontainers and recent docker versions. Remove the unused junit-jupiter-engine.version property.